### PR TITLE
Specify that the .sbat section is ASCII not UTF-8

### DIFF
--- a/SBAT.md
+++ b/SBAT.md
@@ -346,7 +346,7 @@ Adding a .sbat section containing the SBAT metadata structure to PE images.
 | vendor_url | url to look stuff up, contact, whatever.
 
 The format of this .sbat section is comma separated values, or more
-specifically UTF-8 encoded strings.
+specifically ASCII encoded strings.
 
 ## Example sbat sections
 


### PR DESCRIPTION
The SBAT variable is defined as ASCII, but the SBAT section in a binary was defined as UTF-8. These should match.

Use ASCII rather than UTF-8, because naive parsing of UTF-8 could lead to unexpected results. For example the character 'ä' can be encoded as 0xe4 or as 0x61 0x0308, and these should be considered equivalent. The shim is not smart enough to do this. This could lead to missed verifications, if the variable and section use different encodings.

Define everything as ASCII. It's sad not to be able to have 🦀 in our bootloader names, and potentially annoying for vendor names as well, but oh well.